### PR TITLE
add support for internetproxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ and execute it with
 
 ## Configuration
 
-Create `/etc/angry-caching-proxy/config.json` with any of the following keys:
+Configuration can be set using:
+  - a JSON file located at `/etc/angry-caching-proxy/config.json`
+  - a JSON file located at a path defined by command-line parameter `config`
+  - command-line parameters
+
+Command-line parameters will override any configuration set in a config file.
+
+The following configuration keys are available:
 
   - `directory`: Where to store cached requests.
   - `port`: Port to listen.
@@ -53,7 +60,8 @@ Create `/etc/angry-caching-proxy/config.json` with any of the following keys:
     - default: /etc/angry-caching-proxy/triggers.js
   - `triggers`: Array of triggers to activate.
     - default `["apt-get", "npm", "pypi", "rubygems"]`
-  -  proxy: proxy address for internet access (optional)
+  - `proxy`: proxy address for internet access (optional)
+  - `config`: path to config file (command-line only)
 
 
 ## Custom triggers

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Create `/etc/angry-caching-proxy/config.json` with any of the following keys:
     - default: /etc/angry-caching-proxy/triggers.js
   - `triggers`: Array of triggers to activate.
     - default `["apt-get", "npm", "pypi", "rubygems"]`
+  -  proxy: proxy address for internet access (optional)
 
 
 ## Custom triggers

--- a/config.js
+++ b/config.js
@@ -12,7 +12,8 @@ var config = {
         "npm",
         "pypi",
         "rubygems"
-    ]
+    ],
+    proxy: null
 };
 
 try {
@@ -33,6 +34,9 @@ var args = optimist
 
     .describe("workers", "How many node.js processes to use as workes. Defaults to machine cpu core count.")
     .alias("w", "workers")
+
+    .describe("proxy", "Set proxy server for internet access")
+    .alias("px", "proxy")
 
     .alias("h", "help")
     .argv;

--- a/config.js
+++ b/config.js
@@ -16,12 +16,8 @@ var config = {
     proxy: null
 };
 
-try {
-    config = xtend(config, require("/etc/angry-caching-proxy/config.json"));
-} catch(err) { }
-
 var args = optimist
-    .usage("Start Argry Caching Proxy.\n\nUsage: $0")
+    .usage("Start Angry Caching Proxy.\n\nUsage: $0")
 
     .describe("port", "Port to listen")
     .alias("p", "port")
@@ -38,6 +34,9 @@ var args = optimist
     .describe("proxy", "Set proxy server for internet access")
     .alias("px", "proxy")
 
+    .describe("config", "Set path to config file. Other command line parameters override settings from this config file.")
+    .alias("c", "config")
+
     .alias("h", "help")
     .argv;
 
@@ -46,7 +45,15 @@ if (args.help) {
     process.exit(0);
 }
 
+try {
+    config = xtend(config, require(args.config || "/etc/angry-caching-proxy/config.json"));
+} catch(err) {
+    if (args.config) { console.error("could not read config file", err);}
+}
+
+
 if (args.triggers) args.triggers = [].concat(args.triggers);
+
 config = xtend(config, args);
 
 var triggersObject = require("./buildin-triggers");

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var app = express();
 app.set("view engine", "hbs");
 app.set("views", __dirname + "/views");
 
-app.use(require("./proxy")(config.triggerFns, config.directory));
+app.use(require("./proxy")(config.triggerFns, config.directory, config.proxy));
 
 app.get("/", function(req, res, next) {
 

--- a/proxy.js
+++ b/proxy.js
@@ -30,7 +30,10 @@ function toCacheKey(req) {
 
 
 
-module.exports = function(triggerFns, cacheDir) {
+module.exports = function(triggerFns, cacheDir, internetProxy) {
+    if (internetProxy) {
+        request = request.defaults({proxy: internetProxy});    
+    }    
 
     function toCachePath(req) {
         return path.join(cacheDir, toCacheKey(req));


### PR DESCRIPTION
When using angry-caching-proxy in an environment where another proxy server is required to access the Internet, provide a way to configure a proxy url.
