### PR TITLE
Correct "workes" to "workers" in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Create `/etc/angry-caching-proxy/config.json` with any of the following keys:
   - `directory`: Where to store cached requests.
   - `port`: Port to listen.
     - default: 8080
-  - `workes`: Workers to use. Default to machine cpu core count.
+  - `workers`: Workers to use. Default to machine cpu core count.
   - `customTriggers`: Path to custom triggers module.
     - default: /etc/angry-caching-proxy/triggers.js
   - `triggers`: Array of triggers to activate.

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ var args = optimist
     .describe("triggers", "Triggers to activate. Can be defined multiple times.")
     .alias("t", "triggers")
 
-    .describe("workers", "How many node.js processes to use as workes. Defaults to machine cpu core count.")
+    .describe("workers", "How many node.js processes to use as workers. Defaults to machine cpu core count.")
     .alias("w", "workers")
 
     .alias("h", "help")


### PR DESCRIPTION
This is also misspelled on the [homepage](https://www.npmjs.com/package/angry-caching-proxy).